### PR TITLE
feature/binary-on-success

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -116,8 +116,7 @@ function makeHandleResponse(logger, res, convertToBinary) {
         }
         logJson(logger, response);
 
-        // If the CONVERT_TO_BINARY flag was set, return the response as a buffer
-        if (convertToBinary === 'CONVERT_TO_BINARY') {
+        if (convertToBinary === 'CONVERT_TO_BINARY' && response.statusCode < 400) {
             return res
                 .set(response.headers || {})
                 .status(response.statusCode || 200)

--- a/test/claudia_app.js
+++ b/test/claudia_app.js
@@ -51,6 +51,13 @@ function bootstrap() {
         }
     });
 
+    app.get('/error',
+        function () {
+            return new ApiBuilder.ApiResponse({message: 'This is an error and shouldn\'t be converted to binary'}, {'Content-Type': 'application/json'}, 500);
+        },
+        { success: { contentHandling: 'CONVERT_TO_BINARY' } }
+    );
+
     return app;
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -477,7 +477,7 @@ describe('Unit tests for lib/index', function () {
             expect(spy.calledWith(expectedResult)).to.be.eql(true);
         });
 
-        it('CASE 4: Should handle binary data', function () {
+        it('CASE 4: Should handle binary data.', function () {
             const makeHandleResponse = localApi.__get__('makeHandleResponse');
             const spy = sinon.spy();
             const logger = {
@@ -492,6 +492,30 @@ describe('Unit tests for lib/index', function () {
                 body: 'asdjlaasdfiuaslfuaweliuasldifudif'
             };
             const res = getBinaryRes(response.headers, response.statusCode, response.body);
+            const expectedResult = JSON.stringify(response, null, 4);
+
+            const handleResponse = makeHandleResponse(logger, res, 'CONVERT_TO_BINARY');
+            handleResponse(null, response);
+
+            expect(spy.calledOnce).to.be.eql(true);
+            expect(spy.calledWith(expectedResult)).to.be.eql(true);
+        });
+
+        it('CASE 5: Don\'t convert to binary if error', function () {
+            const makeHandleResponse = localApi.__get__('makeHandleResponse');
+            const spy = sinon.spy();
+            const logger = {
+                info: spy
+            };
+            const response = {
+                headers: {
+                    'content-type': 'application/json',
+                    'user-agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.101 Safari/537.36'
+                },
+                statusCode: 400,
+                body: 'asdjlaasdfiuaslfuaweliuasldifudif'
+            };
+            const res = getRes(response.headers, response.statusCode, response.body);
             const expectedResult = JSON.stringify(response, null, 4);
 
             const handleResponse = makeHandleResponse(logger, res, 'CONVERT_TO_BINARY');


### PR DESCRIPTION
## Overview

This PR modifies the check to convert a response body into a base 64 buffer. The check now fails if the response has an "error" status code of >= 400.

## Testing
 * Run the example project by executing `bin/claudia-local-api --api-module test/claudia_app --abbrev 200`.
 * Visit [`localhost:3000/error`](http://localhost:3000/error). The error should be returned as JSON, even though the flag is set to convert to binary.