### PR TITLE
Handle claudia/api-gateway style wildcard path params

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -151,7 +151,7 @@ function getRoutes(routesObj) {
         return {
             resourcePath: route,
             supportedMethods,
-            path: pathParser.Path.createPath(route.replace(/{(.+?)}/g, ':$1'))
+            path: pathParser.Path.createPath(route.replace(/{(.+?)\+}/g, '*$1').replace(/{(.+?)}/g, ':$1'))
         };
     });
 }

--- a/test/claudia_app.js
+++ b/test/claudia_app.js
@@ -58,6 +58,8 @@ function bootstrap() {
         { success: { contentHandling: 'CONVERT_TO_BINARY' } }
     );
 
+    app.get('/wildcard/{wildcard+}', (req) => req.pathParams);
+
     return app;
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -977,4 +977,18 @@ describe('Integration tests for lib/index', function () {
                 expect(err.message).to.be.eql('Received statusCode = 500');
             });
     });
+
+    it('CASE 8: Should be able to handle claudia-form wildcard paths', function () {
+        const params = {
+            url: `http://localhost:${port}/wildcard/one/two/three/four`,
+            method: 'GET',
+            timeout: 200
+        };
+        const expected = JSON.stringify({wildcard: 'one/two/three/four'});
+
+        return makeRequest(params)
+            .then(function (result) {
+                expect(result.body).to.deep.eql(expected);
+            });
+    });
 });


### PR DESCRIPTION
## Overview

`claudia-api-builder` allows you to define wildcard path params in the form of `/{param+}/` that capture the value of the entire path from that param onwards. And example can be found in [this example project](https://github.com/claudiajs/example-projects/tree/master/web-api-generic-handlers):
```
api.get('/dynamic/{proxy+}', function (request) {
	'use strict';
	return 'You called ' + request.pathParams.proxy;
}, { success: { contentType: 'text/plain'}});
```

Since this syntax isn't conventional `express` syntax, `claudia-local-api` wasn't able to handle it and would crash if you tried to put a path like this in your project. This PR adds a regex that converts `claudia`'s wildcard syntax into syntax that the dependency `path-parser` can understand.

## Testing Instructions
 * Run the test project with the command `bin/claudia-local-api --api-module test/claudia_app`
 * Visit the endpoint [`localhost:3000/wildcard/*`](http://localhost:3000/wildcard/anything/can/go/here). Navigate to any variant on that path, and the server should handle it and give you the `pathParams` object back in response.